### PR TITLE
Update Terraform to 1.2.7 and Terragrunt to 0.38.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM hashicorp/terraform:1.1.9
+FROM hashicorp/terraform:1.2.7
 
 ## Install packages
 RUN apk add --no-cache bash make postgresql
 
 ## Install Terragrunt
-ARG TERRAGRUNT_VERSION=0.36.12
+ARG TERRAGRUNT_VERSION=0.38.7
 RUN wget "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64" -O /usr/local/bin/terragrunt --no-verbose \
     && chmod +x /usr/local/bin/terragrunt
 
-## remove WORKDIR and ENTRYPOINT FROM terraform image
+## remove WORKDIR and ENTRYPOINT FROM base image
 WORKDIR /
 ENTRYPOINT []

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Terragrunt
 
 This Docker image contains the following primary binaries:
 
-* `terraform`
-* `terragrunt`
+* [`terraform`](https://github.com/hashicorp/terraform/releases)
+* [`terragrunt`](https://github.com/gruntwork-io/terragrunt/releases)
 
 Terraform version compatibility table:
 
@@ -57,5 +57,5 @@ Execute commands inside the container:
 
 ```
 bash-5.1# terragrunt -v
-terragrunt version v0.36.12
+terragrunt version vX.Y.Z
 ```


### PR DESCRIPTION
Following compatibility table: https://terragrunt.gruntwork.io/docs/getting-started/supported-terraform-versions/